### PR TITLE
Increase exec's buffer size, remove unnecessary function

### DIFF
--- a/lib/ytdl/ytdl.js
+++ b/lib/ytdl/ytdl.js
@@ -3,12 +3,15 @@ const exec = require('child_process').exec;
 const path = require('path');
 
 const YTDL_MODULE_PATH = path.join(__dirname, 'node_modules/youtube-dl/bin/youtube-dl');
+const PROCESS_OPTIONS = {
+    maxBuffer: 10 * 1024 * 1024 // 10 MB; Default is 1 MB which is in some cases not enough
+};
 
 function download(url, dstPath, options) {
     const emitter = new EventEmitter();
     const args = options.concat(['--print-json', '-o', `'${dstPath}'`]);
 
-    const proc = exec(`python ${YTDL_MODULE_PATH} ${args.join(' ')} ${url}`);
+    const proc = exec(`python ${YTDL_MODULE_PATH} ${args.join(' ')} ${url}`, PROCESS_OPTIONS);
 
     let temporaryJson = '';
     let finalJson = null;
@@ -32,7 +35,7 @@ function download(url, dstPath, options) {
 
     proc.on('exit', (code) => {
         if (finalJson === null) {
-            finalJson = tryReparsingJson(tryRemovingFragments(temporaryJson));
+            finalJson = tryReparsingJson(temporaryJson);
             if (finalJson !== null) {
                 emitter.emit('info', finalJson);
             }
@@ -43,21 +46,13 @@ function download(url, dstPath, options) {
     return emitter;
 }
 
-function tryRemovingFragments(incompleteJson) {
-    const fragmentsPosition = incompleteJson.indexOf(', "fragments"');
-    if (fragmentsPosition > 0) {
-        return incompleteJson.substr(0, fragmentsPosition) + '}';
-    }
-    return incompleteJson;
-}
-
 function tryReparsingJson(jsonData) {
     let json = null;
     try {
         const tmpJson = JSON.parse(jsonData);
         json = tmpJson;
     } catch (e) {
-        // nothing to catch
+        // nothing to catch, JSON is not complete yet
     }
     return json;
 }
@@ -65,7 +60,7 @@ function tryReparsingJson(jsonData) {
 function getInfo(url, options) {
     const emitter = new EventEmitter();
 
-    const proc = exec(`python ${YTDL_MODULE_PATH} ${options.join(' ')} ${url}`);
+    const proc = exec(`python ${YTDL_MODULE_PATH} ${options.join(' ')} ${url}`, PROCESS_OPTIONS);
 
     let temporaryJson = '';
     let finalJson = null;
@@ -89,7 +84,7 @@ function getInfo(url, options) {
 
     proc.on('exit', (code) => {
         if (finalJson === null) {
-            finalJson = tryReparsingJson(tryRemovingFragments(temporaryJson));
+            finalJson = tryReparsingJson(temporaryJson);
             if (finalJson !== null) {
                 emitter.emit('info', finalJson);
             }


### PR DESCRIPTION
Buffer size of `child_process.exec()` is 1 MB by default. The buffer is used for output of commands.

In some cases (when downloaded video is long), `stdout` reaches 1 MB and in that case Node terminates such process and output is truncated. This also stops download of the video.

By setting the buffer size to 10 MB we ensure it doesn't happen again.

The reason why output JSON is such big is that it contains `fragments` property with all chunks.